### PR TITLE
Issue #46 Add Code Formatter and CI/CD Linter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         with:
           fetch-depth: 2
 

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
         "psr-4": {"Utopia\\Tests\\Compression\\":"tests/Compression"}
     },
     "scripts": {
-        "lint": "./vendor/bin/pint --test",
-        "format": "./vendor/bin/pint"
+        "lint": "./vendor/bin/pint --test --config pint.json",
+        "format": "./vendor/bin/pint --config pint.json"
     },
     "require": {
         "php": ">=8.0"

--- a/pint.json
+++ b/pint.json
@@ -1,0 +1,6 @@
+{
+    "preset": "psr12",
+    "exclude": [
+        "tests/resources"
+    ]
+}


### PR DESCRIPTION
In response to issue #46, "Add code formatter and CI/CD linter", I configured Pint to the same settings as the Open Runtimes Executor repository. More specifically, I added a new file, pint.json, and configured it with the lint and format scripts in the composer.json file. I then updated "uses: actions/checkout@v3" to "uses: actions/checkout@v2" in the linter.yml file. Now the linter script runs and flags errors in new code when triggered by a pull request.