### PR TITLE
feat(zstd): enable by default for accept encoding

### DIFF
--- a/src/Compression/Compression.php
+++ b/src/Compression/Compression.php
@@ -112,6 +112,7 @@ abstract class Compression
 
         if (empty($supported)) {
             $supported = [
+                self::ZSTD => Algorithms\Zstd::isSupported(),
                 self::BROTLI => Algorithms\Brotli::isSupported(),
                 self::GZIP => Algorithms\GZIP::isSupported(),
                 self::DEFLATE => Algorithms\Deflate::isSupported(),


### PR DESCRIPTION
Enables `zstd` as a supported algorithm inside accept-encoding headers.